### PR TITLE
Add max_temperature to AnnealingConfig and clamp temp in engine

### DIFF
--- a/crates/berth-alloc-solver/src/meta/config.rs
+++ b/crates/berth-alloc-solver/src/meta/config.rs
@@ -83,6 +83,7 @@ pub struct AnnealingConfig {
     pub initial_temperature: f64,
     pub cooling_rate: f64,
     pub min_temperature: f64,
+    pub max_temperature: f64,
 }
 
 impl Default for AnnealingConfig {
@@ -91,6 +92,7 @@ impl Default for AnnealingConfig {
             initial_temperature: 1.0,
             cooling_rate: 0.9995,
             min_temperature: 1e-9,
+            max_temperature: 100.0,
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the simulated annealing configuration and temperature management in the `berth-alloc-solver`. The main improvements include introducing a maximum temperature parameter, clamping the effective temperature within bounds, refining temperature normalization for softmax selection, and improving logging for better traceability.

**Annealing configuration improvements:**

* Added a new `max_temperature` field to the `AnnealingConfig` struct and set its default value to 100.0. This allows the annealing process to cap the effective temperature, preventing it from exceeding a specified maximum. [[1]](diffhunk://#diff-868401cd9c9f577cd9c4afca0d943dc144080138e2febda1e23e2a2d451e2a01R86) [[2]](diffhunk://#diff-868401cd9c9f577cd9c4afca0d943dc144080138e2febda1e23e2a2d451e2a01R95)

**Temperature management and selection logic:**

* Updated the effective temperature calculation in the annealing engine to clamp its value between `min_temperature` and the new `max_temperature`, improving stability during reheats.
* Changed the normalization for the softmax temperature (`tau`) to use the base temperature rather than the reheated value, ensuring more stable selection behavior.

**Logging and traceability:**

* Enhanced logging to record the base, scale, and effective temperature at each iteration for improved debugging and analysis.

**State update handling:**

* Reset `temp_scale` and `explore_boost_until` to their defaults when a new best feasible state is found, ensuring proper exploration behavior.